### PR TITLE
chore: promote php-helloworld to version 0.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-0.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-0.0.1-release.yaml
@@ -1,0 +1,49 @@
+# Source: php-helloworld/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-12T08:02:52Z"
+  deletionTimestamp: null
+  name: 'php-helloworld-0.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.1
+      sha: 8f4c3d3f1ed064593d345f8d248708c68434a2e5
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: f507eb240b7a66ed3bc8d6aebf85f20f635a2337
+    - author:
+        email: 1271580969@qq.com
+        name: denglanlan
+      branch: master
+      committer:
+        email: 1271580969@qq.com
+        name: denglanlan
+      message: |
+        chore: Jenkins X build pack
+      sha: b87e1127c5da6772757a7fab34655232c98adb96
+  gitHttpUrl: https://github.com/denglanlan/php-helloworld
+  gitOwner: denglanlan
+  gitRepository: php-helloworld
+  name: 'php-helloworld'
+  releaseNotesURL: https://github.com/denglanlan/php-helloworld/releases/tag/v0.0.1
+  version: v0.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-ingress.yaml
+++ b/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: php-helloworld/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: php-helloworld
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: php-helloworld
+              servicePort: 80
+      host: php-helloworld-jx-staging.jx3.sky-cloud.net

--- a/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-php-helloworld-deploy.yaml
+++ b/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-php-helloworld-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: php-helloworld/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: php-helloworld-php-helloworld
+  labels:
+    draft: draft-app
+    chart: "php-helloworld-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: php-helloworld-php-helloworld
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: php-helloworld-php-helloworld
+    spec:
+      serviceAccountName: php-helloworld-php-helloworld
+      containers:
+        - name: php-helloworld
+          image: "ghcr.io/denglanlan/php-helloworld:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-php-helloworld-sa.yaml
+++ b/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-php-helloworld-sa.yaml
@@ -1,0 +1,8 @@
+# Source: php-helloworld/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: php-helloworld-php-helloworld
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-svc.yaml
+++ b/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-svc.yaml
@@ -1,0 +1,21 @@
+# Source: php-helloworld/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: php-helloworld
+  labels:
+    chart: "php-helloworld-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: php-helloworld-php-helloworld

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,13 +13,10 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/php-helloworld
   version: 0.0.1
   name: php-helloworld
-  forceNamespace: ""
-  skipDeps: null
+  values:
+  - jx-values.yaml
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,13 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
+- chart: dev/php-helloworld
+  version: 0.0.1
+  name: php-helloworld
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote php-helloworld to version 0.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge