### PR TITLE
chore: promote php-helloworld to version 0.0.2 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-0.0.2-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-12T08:02:52Z"
+  creationTimestamp: "2020-12-12T08:30:14Z"
   deletionTimestamp: null
-  name: 'php-helloworld-0.0.1'
+  name: 'php-helloworld-0.0.2'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.1
-      sha: 8f4c3d3f1ed064593d345f8d248708c68434a2e5
+        chore: release 0.0.2
+      sha: 787797b2b490913931a26053cb79ef30ed922647
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,21 +29,20 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: f507eb240b7a66ed3bc8d6aebf85f20f635a2337
+      sha: 3e6a6044967dc2015a1b8604bc6304ccaadb7370
     - author:
-        email: 1271580969@qq.com
-        name: denglanlan
+        email: 46771578+denglanlan@users.noreply.github.com
+        name: 晴天。
       branch: master
       committer:
-        email: 1271580969@qq.com
-        name: denglanlan
-      message: |
-        chore: Jenkins X build pack
-      sha: b87e1127c5da6772757a7fab34655232c98adb96
+        email: noreply@github.com
+        name: GitHub
+      message: Update Dockerfile
+      sha: 978867ee250b4364c04a26e29ce6c308b857eda8
   gitHttpUrl: https://github.com/denglanlan/php-helloworld
   gitOwner: denglanlan
   gitRepository: php-helloworld
   name: 'php-helloworld'
-  releaseNotesURL: https://github.com/denglanlan/php-helloworld/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/denglanlan/php-helloworld/releases/tag/v0.0.2
+  version: v0.0.2
 status: {}

--- a/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-php-helloworld-deploy.yaml
+++ b/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-php-helloworld-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: php-helloworld-php-helloworld
   labels:
     draft: draft-app
-    chart: "php-helloworld-0.0.1"
+    chart: "php-helloworld-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: php-helloworld-php-helloworld
       containers:
         - name: php-helloworld
-          image: "ghcr.io/denglanlan/php-helloworld:0.0.1"
+          image: "ghcr.io/denglanlan/php-helloworld:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-svc.yaml
+++ b/config-root/namespaces/jx-staging/php-helloworld/php-helloworld-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: php-helloworld
   labels:
-    chart: "php-helloworld-0.0.1"
+    chart: "php-helloworld-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,10 +13,15 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/php-helloworld
-  version: 0.0.1
+  version: 0.0.2
   name: php-helloworld
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,15 +13,10 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/php-helloworld
   version: 0.0.2
   name: php-helloworld
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote php-helloworld to version 0.0.2 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge