### PR TITLE
chore: promote node-test to version 1.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/node-test/node-test-1.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/node-test/node-test-1.0.1-release.yaml
@@ -1,0 +1,49 @@
+# Source: node-test/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-12T09:02:58Z"
+  deletionTimestamp: null
+  name: 'node-test-1.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 1.0.1
+      sha: 948dc0074a3bb5027cd409d9c9bb9f0cfb9b2ec7
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 9757f9991cc911e9d1cdb95a9435ffcea8b3eea4
+    - author:
+        email: 1271580969@qq.com
+        name: denglanlan
+      branch: master
+      committer:
+        email: 1271580969@qq.com
+        name: denglanlan
+      message: |
+        chore: Jenkins X build pack
+      sha: 0f48ad935dd8f8bd534823562758d2102a652abb
+  gitHttpUrl: https://github.com/denglanlan/node-test
+  gitOwner: denglanlan
+  gitRepository: node-test
+  name: 'node-test'
+  releaseNotesURL: https://github.com/denglanlan/node-test/releases/tag/v1.0.1
+  version: v1.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/node-test/node-test-ingress.yaml
+++ b/config-root/namespaces/jx-staging/node-test/node-test-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: node-test/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: node-test
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: node-test
+              servicePort: 80
+      host: node-test-jx-staging.jx3.sky-cloud.net

--- a/config-root/namespaces/jx-staging/node-test/node-test-node-test-deploy.yaml
+++ b/config-root/namespaces/jx-staging/node-test/node-test-node-test-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: node-test/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-test-node-test
+  labels:
+    draft: draft-app
+    chart: "node-test-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: node-test-node-test
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: node-test-node-test
+    spec:
+      serviceAccountName: node-test-node-test
+      containers:
+        - name: node-test
+          image: "ghcr.io/denglanlan/node-test:1.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/node-test/node-test-node-test-sa.yaml
+++ b/config-root/namespaces/jx-staging/node-test/node-test-node-test-sa.yaml
@@ -1,0 +1,8 @@
+# Source: node-test/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-test-node-test
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/node-test/node-test-svc.yaml
+++ b/config-root/namespaces/jx-staging/node-test/node-test-svc.yaml
@@ -1,0 +1,21 @@
+# Source: node-test/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-test
+  labels:
+    chart: "node-test-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: node-test-node-test

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,10 +13,20 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/php-helloworld
   version: 0.0.2
   name: php-helloworld
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
+- chart: dev/node-test
+  version: 1.0.1
+  name: node-test
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,20 +13,15 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/php-helloworld
   version: 0.0.2
   name: php-helloworld
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/node-test
   version: 1.0.1
   name: node-test
-  forceNamespace: ""
-  skipDeps: null
+  values:
+  - jx-values.yaml
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote node-test to version 1.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge