### PR TITLE
chore: promote node-http to version 1.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/node-http/node-http-1.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/node-http/node-http-1.0.1-release.yaml
@@ -1,0 +1,49 @@
+# Source: node-http/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-14T06:25:00Z"
+  deletionTimestamp: null
+  name: 'node-http-1.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 1.0.1
+      sha: 87766030fefa7eba365a1b16549357c0608a8bcd
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: c4b03959b23e6fa13cc53d45a3252a90c1117b18
+    - author:
+        email: 1271580969@qq.com
+        name: denglanlan
+      branch: master
+      committer:
+        email: 1271580969@qq.com
+        name: denglanlan
+      message: |
+        chore: Jenkins X build pack
+      sha: 0b5026fdff0911483a1e721632195d42da0b907e
+  gitHttpUrl: https://github.com/denglanlan/node-http
+  gitOwner: denglanlan
+  gitRepository: node-http
+  name: 'node-http'
+  releaseNotesURL: https://github.com/denglanlan/node-http/releases/tag/v1.0.1
+  version: v1.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/node-http/node-http-ingress.yaml
+++ b/config-root/namespaces/jx-staging/node-http/node-http-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: node-http/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: node-http
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: node-http
+              servicePort: 80
+      host: node-http-jx-staging.jx3.sky-cloud.net

--- a/config-root/namespaces/jx-staging/node-http/node-http-node-http-deploy.yaml
+++ b/config-root/namespaces/jx-staging/node-http/node-http-node-http-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: node-http/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-http-node-http
+  labels:
+    draft: draft-app
+    chart: "node-http-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: node-http-node-http
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: node-http-node-http
+    spec:
+      serviceAccountName: node-http-node-http
+      containers:
+        - name: node-http
+          image: "ghcr.io/denglanlan/node-http:1.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/node-http/node-http-node-http-sa.yaml
+++ b/config-root/namespaces/jx-staging/node-http/node-http-node-http-sa.yaml
@@ -1,0 +1,8 @@
+# Source: node-http/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-http-node-http
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/node-http/node-http-svc.yaml
+++ b/config-root/namespaces/jx-staging/node-http/node-http-svc.yaml
@@ -1,0 +1,21 @@
+# Source: node-http/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-http
+  labels:
+    chart: "node-http-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: node-http-node-http

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,27 +13,20 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/php-helloworld
   version: 0.0.2
   name: php-helloworld
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/node-test
   version: 1.0.1
   name: node-test
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/node-http
   version: 1.0.1
   name: node-http
-  forceNamespace: ""
-  skipDeps: null
+  values:
+  - jx-values.yaml
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,15 +13,27 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/php-helloworld
   version: 0.0.2
   name: php-helloworld
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/node-test
   version: 1.0.1
   name: node-test
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
+- chart: dev/node-http
+  version: 1.0.1
+  name: node-http
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote node-http to version 1.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge