### PR TITLE
chore: promote node-hrrp3 to version 1.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/node-hrrp3/node-hrrp3-1.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/node-hrrp3/node-hrrp3-1.0.1-release.yaml
@@ -1,0 +1,49 @@
+# Source: node-hrrp3/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-14T06:32:57Z"
+  deletionTimestamp: null
+  name: 'node-hrrp3-1.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 1.0.1
+      sha: bca5c0078d3e9db3780f71a5ddae78baa76e5334
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: f09ae913df2f748da202c1bb969dd0fc1eb8d868
+    - author:
+        email: 1271580969@qq.com
+        name: denglanlan
+      branch: master
+      committer:
+        email: 1271580969@qq.com
+        name: denglanlan
+      message: |
+        chore: Jenkins X build pack
+      sha: 5d92fc036248beda3eec2fca3710187d209f0919
+  gitHttpUrl: https://github.com/denglanlan/node-hrrp3
+  gitOwner: denglanlan
+  gitRepository: node-hrrp3
+  name: 'node-hrrp3'
+  releaseNotesURL: https://github.com/denglanlan/node-hrrp3/releases/tag/v1.0.1
+  version: v1.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/node-hrrp3/node-hrrp3-ingress.yaml
+++ b/config-root/namespaces/jx-staging/node-hrrp3/node-hrrp3-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: node-hrrp3/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: node-hrrp3
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: node-hrrp3
+              servicePort: 80
+      host: node-hrrp3-jx-staging.jx3.sky-cloud.net

--- a/config-root/namespaces/jx-staging/node-hrrp3/node-hrrp3-node-hrrp3-deploy.yaml
+++ b/config-root/namespaces/jx-staging/node-hrrp3/node-hrrp3-node-hrrp3-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: node-hrrp3/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-hrrp3-node-hrrp3
+  labels:
+    draft: draft-app
+    chart: "node-hrrp3-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: node-hrrp3-node-hrrp3
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: node-hrrp3-node-hrrp3
+    spec:
+      serviceAccountName: node-hrrp3-node-hrrp3
+      containers:
+        - name: node-hrrp3
+          image: "ghcr.io/denglanlan/node-hrrp3:1.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/node-hrrp3/node-hrrp3-node-hrrp3-sa.yaml
+++ b/config-root/namespaces/jx-staging/node-hrrp3/node-hrrp3-node-hrrp3-sa.yaml
@@ -1,0 +1,8 @@
+# Source: node-hrrp3/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-hrrp3-node-hrrp3
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/node-hrrp3/node-hrrp3-svc.yaml
+++ b/config-root/namespaces/jx-staging/node-hrrp3/node-hrrp3-svc.yaml
@@ -1,0 +1,21 @@
+# Source: node-hrrp3/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-hrrp3
+  labels:
+    chart: "node-hrrp3-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: node-hrrp3-node-hrrp3

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,34 +13,25 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/php-helloworld
   version: 0.0.2
   name: php-helloworld
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/node-test
   version: 1.0.1
   name: node-test
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/node-http
   version: 1.0.1
   name: node-http
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/node-hrrp3
   version: 1.0.1
   name: node-hrrp3
-  forceNamespace: ""
-  skipDeps: null
+  values:
+  - jx-values.yaml
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,20 +13,34 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/php-helloworld
   version: 0.0.2
   name: php-helloworld
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/node-test
   version: 1.0.1
   name: node-test
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/node-http
   version: 1.0.1
   name: node-http
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
+- chart: dev/node-hrrp3
+  version: 1.0.1
+  name: node-hrrp3
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote node-hrrp3 to version 1.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge