### PR TITLE
chore: promote python-three to version 0.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/python-three/python-three-0.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/python-three/python-three-0.0.1-release.yaml
@@ -1,0 +1,49 @@
+# Source: python-three/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-14T06:47:34Z"
+  deletionTimestamp: null
+  name: 'python-three-0.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.1
+      sha: 9baa43e45cc7fe396a059b53e1a483c3d66a163a
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: f518cbbef390402c9a4c3a2a6cea5b7f915692c5
+    - author:
+        email: 1271580969@qq.com
+        name: denglanlan
+      branch: master
+      committer:
+        email: 1271580969@qq.com
+        name: denglanlan
+      message: |
+        chore: Jenkins X build pack
+      sha: 7a5a49ecf92156a29be78c1b2c4a89a0753ccaf1
+  gitHttpUrl: https://github.com/denglanlan/python-three
+  gitOwner: denglanlan
+  gitRepository: python-three
+  name: 'python-three'
+  releaseNotesURL: https://github.com/denglanlan/python-three/releases/tag/v0.0.1
+  version: v0.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/python-three/python-three-ingress.yaml
+++ b/config-root/namespaces/jx-staging/python-three/python-three-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: python-three/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: python-three
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: python-three
+              servicePort: 80
+      host: python-three-jx-staging.jx3.sky-cloud.net

--- a/config-root/namespaces/jx-staging/python-three/python-three-python-three-deploy.yaml
+++ b/config-root/namespaces/jx-staging/python-three/python-three-python-three-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: python-three/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: python-three-python-three
+  labels:
+    draft: draft-app
+    chart: "python-three-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: python-three-python-three
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: python-three-python-three
+    spec:
+      serviceAccountName: python-three-python-three
+      containers:
+        - name: python-three
+          image: "ghcr.io/denglanlan/python-three:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/python-three/python-three-python-three-sa.yaml
+++ b/config-root/namespaces/jx-staging/python-three/python-three-python-three-sa.yaml
@@ -1,0 +1,8 @@
+# Source: python-three/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: python-three-python-three
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/python-three/python-three-svc.yaml
+++ b/config-root/namespaces/jx-staging/python-three/python-three-svc.yaml
@@ -1,0 +1,21 @@
+# Source: python-three/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: python-three
+  labels:
+    chart: "python-three-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: python-three-python-three

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,25 +13,41 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/php-helloworld
   version: 0.0.2
   name: php-helloworld
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/node-test
   version: 1.0.1
   name: node-test
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/node-http
   version: 1.0.1
   name: node-http
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/node-hrrp3
   version: 1.0.1
   name: node-hrrp3
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
+- chart: dev/python-three
+  version: 0.0.1
+  name: python-three
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,41 +13,30 @@ releases:
   name: deng-test-three
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/php-helloworld
   version: 0.0.2
   name: php-helloworld
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/node-test
   version: 1.0.1
   name: node-test
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/node-http
   version: 1.0.1
   name: node-http
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/node-hrrp3
   version: 1.0.1
   name: node-hrrp3
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/python-three
   version: 0.0.1
   name: python-three
-  forceNamespace: ""
-  skipDeps: null
+  values:
+  - jx-values.yaml
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote python-three to version 0.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge